### PR TITLE
Bug ghofund dao page

### DIFF
--- a/packages/nextjs/components/BuildersInfo.tsx
+++ b/packages/nextjs/components/BuildersInfo.tsx
@@ -54,8 +54,6 @@ const BuildersInfo = ({ streamContract }: { streamContract: { address: string; a
 
   const sortedBuilders = allBuildersData && [...allBuildersData].reverse();
 
-  console.log("All withdraw events are", sortedWithdrawEvents);
-
   return (
     <div className="flex flex-col md:flex-row gap-3">
       {/* Builders Div */}

--- a/packages/nextjs/hooks/useEventHistory.ts
+++ b/packages/nextjs/hooks/useEventHistory.ts
@@ -69,9 +69,7 @@ export const useEventHistory = <
   const readEvents = async (fromBlock?: bigint) => {
     setIsLoading(true);
     try {
-      if (!deployedContractData) {
-        throw new Error("Contract not found");
-      }
+      if (!deployedContractData.address || !deployedContractData.abi) throw new Error("Contract address not found");
 
       if (!enabled) {
         throw new Error("Hook disabled");
@@ -175,8 +173,6 @@ export const useEventHistory = <
       >,
     [events],
   );
-
-  console.log("eventHistoryData", eventHistoryData);
 
   return {
     data: eventHistoryData,


### PR DESCRIPTION
### Description : 

Actually there was a bug in `useEventHistory` , We were not doing proper `address` check if its undefined or not, and even if it was undefined we were making a `getLogs` request. 

When you call [`publicClient.getLogs`](https://v1.viem.sh/docs/actions/public/getLogs.html#address-1) passing address as `undefined` it finds all the logs from various contract addresses which matches the event. Hence we were getting random events from random contracts. 

Checkout this example: https://stackblitz.com/edit/wevm-viem-gpjn8l?file=index.ts

Note related to this PR / discussion: But while tinkering found that while making `eth_getLogs` request your `fromBlock` - `toBlock` should be < 800 blocks others will error (at least public cloudfare node does it) 